### PR TITLE
Improve open source contributor docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,36 @@
+---
+name: Bug report
+about: Report a reproducible WebApp problem
+title: "[Bug]: "
+labels: bug
+assignees: ""
+---
+
+## What happened?
+
+Describe the bug clearly.
+
+## Steps to reproduce
+
+1. 
+2. 
+3. 
+
+## Expected behavior
+
+What did you expect to happen?
+
+## Actual behavior
+
+What happened instead?
+
+## Environment
+
+- Browser:
+- Device:
+- Branch or version:
+- Docker or local run:
+
+## Screenshots or logs
+
+Add screenshots, browser console errors, or application logs if available.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,23 @@
+---
+name: Feature request
+about: Suggest a WebApp improvement
+title: "[Feature]: "
+labels: enhancement
+assignees: ""
+---
+
+## Problem
+
+What user or contributor problem would this solve?
+
+## Proposed solution
+
+Describe the behavior you would like.
+
+## Alternatives considered
+
+List any alternatives or tradeoffs.
+
+## Additional context
+
+Add mockups, screenshots, examples, or links if helpful.

--- a/.github/ISSUE_TEMPLATE/good_first_issue.md
+++ b/.github/ISSUE_TEMPLATE/good_first_issue.md
@@ -1,0 +1,24 @@
+---
+name: Good first issue
+about: Template for small, well-scoped contributor tasks
+title: "[Good first issue]: "
+labels: good first issue
+assignees: ""
+---
+
+## Goal
+
+Describe the small outcome expected from this issue.
+
+## Suggested files
+
+List the likely files or areas to inspect.
+
+## Acceptance criteria
+
+- [ ] 
+- [ ] 
+
+## Hints
+
+Add context that helps a new contributor get started.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,18 @@
+## Summary
+
+Describe what changed and why.
+
+## Testing
+
+- [ ] `dotnet build`
+- [ ] Manual WebApp test, if relevant
+
+## Screenshots
+
+Add screenshots or short videos for visible UI changes.
+
+## Checklist
+
+- [ ] I kept the change focused.
+- [ ] I updated documentation where needed.
+- [ ] I did not commit secrets or local configuration.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,17 @@
+# Code of Conduct
+
+## Our Pledge
+
+We want TennisScoreWebApp to be a welcoming and useful project for contributors of different backgrounds and experience levels.
+
+Participants are expected to communicate with respect, assume good intent, and focus criticism on ideas, code, and project outcomes.
+
+## Unacceptable Behavior
+
+Unacceptable behavior includes harassment, insults, discriminatory language, personal attacks, publishing private information, or repeated disruption of project discussions.
+
+## Enforcement
+
+Project maintainers may remove comments, close issues, reject contributions, or block participants who do not follow this code of conduct.
+
+If you need to report a concern, open a private channel with the maintainer listed in the repository profile or contact the project owner through GitHub.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,58 @@
+# Contributing to TennisScoreWebApp
+
+Thanks for your interest in contributing. TennisScoreWebApp is the Blazor Server frontend for an open-source live tennis scoring platform aimed at clubs, academies, associations, and amateur tournaments.
+
+## Before You Start
+
+- Check existing issues and pull requests to avoid duplicate work.
+- For larger UX or architecture changes, open an issue first.
+- Keep pull requests focused and reasonably small.
+
+## Local Setup
+
+Requirements:
+
+- .NET 10 SDK
+- A running TennisScoresAPI instance
+
+Common commands:
+
+```bash
+dotnet restore
+dotnet build
+dotnet run --project TennisScoreWebApp/TennisScoreWebApp.csproj
+```
+
+By default, the WebApp reads API URLs from `TennisScoreWebApp/appsettings.json`. You can override them with:
+
+```bash
+export SCORE_API_URL="http://localhost:5227/"
+export SCOREHUB_URL="http://localhost:5227/scoreHub"
+dotnet run --project TennisScoreWebApp/TennisScoreWebApp.csproj
+```
+
+## API Client Generation
+
+The API client is generated with NSwag from `TennisScoreWebApp/ApiDefinitions/swagger.json`.
+
+When the API contract changes, regenerate the client and commit both the OpenAPI file and generated client:
+
+```bash
+bash TennisScoreWebApp/ApiDefinitions/command.sh
+```
+
+## Pull Request Guidelines
+
+- Explain the problem and the solution clearly.
+- Include screenshots or short videos for visible UI changes.
+- Test the main flow manually: tournaments, players, match creation, scoring, and live updates.
+- Keep API client changes aligned with the backend contract.
+- Do not commit secrets, production passwords, local `.env` files, or generated personal data.
+
+## Useful Contribution Areas
+
+- Courtside scoring UX.
+- Mobile and tablet responsive behavior.
+- Real-time score update feedback.
+- Accessibility.
+- Deployment and operations documentation.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,29 @@
 # TennisScoreWebApp
 
+[![Build and publish](https://github.com/1fini/TennisScoreWebApp/actions/workflows/docker-build-webapp.yml/badge.svg)](https://github.com/1fini/TennisScoreWebApp/actions/workflows/docker-build-webapp.yml)
+[![Docker image](https://img.shields.io/docker/v/1fini/tennisscore-webapp/latest?label=dockerhub)](https://hub.docker.com/r/1fini/tennisscore-webapp)
+[![License: GPL v3](https://img.shields.io/badge/license-GPLv3-blue.svg)](LICENSE)
+[![.NET](https://img.shields.io/badge/.NET-10-512BD4)](https://dotnet.microsoft.com/)
+
 Blazor Server web application for managing tennis tournaments, players, matches, and live scoring.
 
 TennisScoreWebApp is the user-facing part of the TennisScore MVP. It consumes the TennisScoresAPI backend, listens to live score updates over SignalR, and provides a compact interface for running tournament matches point by point.
+
+## Why This Project Exists
+
+TennisScore is an open-source live tennis scoring platform for clubs, academies, associations, and amateur tournaments. The goal is to make it simple to create tournaments, score matches courtside, and share live updates without relying on expensive or closed tournament software.
+
+This repository contains the Blazor Server WebApp. The backend API and scoring domain live in the companion repository:
+
+- https://github.com/1fini/TennisScoresAPI
+
+## Demo
+
+The MVP is deployed at:
+
+- https://live.tennismentorsclub.fr
+
+The public demo can be protected by Basic Auth while the project is still in MVP mode. If you are interested in contributing and need access, open a GitHub issue.
 
 ## Features
 
@@ -114,6 +135,20 @@ export SCORE_API_URL="http://localhost:5227/"
 export SCOREHUB_URL="http://localhost:5227/scoreHub"
 dotnet run --project TennisScoreWebApp/TennisScoreWebApp.csproj
 ```
+
+## Contributing
+
+Contributions are welcome. The most useful areas right now are:
+
+- scoring screen usability for courtside usage;
+- mobile and tablet responsive behavior;
+- real-time SignalR experience and visual feedback;
+- accessibility and keyboard-friendly workflows;
+- deployment documentation and production hardening.
+
+Read [CONTRIBUTING.md](CONTRIBUTING.md) before opening a pull request.
+
+Good first contributions are usually small UI polish tasks, documentation fixes, accessibility improvements, or issues labeled `good first issue`.
 
 ## API Client Generation
 
@@ -252,6 +287,7 @@ This makes the stack suitable for Raspberry Pi deployments.
 ## Roadmap
 
 - Add health checks for WebApp and API.
+- Add temporary undo for the last scored point once the API supports it.
 - Replace Basic Auth with application-level authentication when user onboarding needs it.
 - Harden production headers and forwarded header handling behind Traefik.
 - Improve observability with structured logs and deployment documentation.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,22 @@
+# Security Policy
+
+## Supported Versions
+
+The `main` branch is the only currently supported version.
+
+## Reporting a Vulnerability
+
+Please do not open a public issue for sensitive security problems.
+
+Report vulnerabilities privately through GitHub security advisories when available, or contact the repository owner through GitHub with:
+
+- a short description of the issue;
+- steps to reproduce;
+- potential impact;
+- any suggested mitigation.
+
+## Secrets
+
+Never commit production secrets, Basic Auth hashes, private keys, tokens, local `.env` files, or deployment credentials.
+
+Use environment variables, GitHub secrets, Docker secrets, or server-local configuration for sensitive values.


### PR DESCRIPTION
## Summary

- Add README badges, project positioning, demo link, contribution guidance, and roadmap entry.
- Add CONTRIBUTING, CODE_OF_CONDUCT, and SECURITY documents.
- Add bug report, feature request, good first issue, and pull request templates.

## Validation

- `dotnet build --configuration Release` passed locally.
- Documentation-only changes; no runtime code changed.