### PR TITLE
Add PostgreSQL backup and restore scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@
 *.userosscache
 *.sln.docstates
 *.env
+backups/
+*.dump
+*.dump.gz
 
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs

--- a/README.md
+++ b/README.md
@@ -245,6 +245,47 @@ PostgreSQL data is stored in a Docker volume:
 
 Do not remove this volume unless you intentionally want to reset database data.
 
+### Backup and Restore
+
+PostgreSQL backups should be stored outside Git, ideally on the production server under a directory such as:
+
+```text
+/opt/tennisscore/backups
+```
+
+Create a compressed PostgreSQL custom-format backup:
+
+```bash
+BACKUP_DIR=/opt/tennisscore/backups bash ./scripts/backup-postgres.sh
+```
+
+By default, the backup script:
+
+- reads `.env.prod` and `docker-compose.prod.yml`;
+- runs `pg_dump` from the running `postgres` service;
+- writes a file named `tennisscore-postgres-<timestamp>.dump.gz`;
+- removes backups older than 14 days.
+
+Override retention when needed:
+
+```bash
+RETENTION_DAYS=30 BACKUP_DIR=/opt/tennisscore/backups bash ./scripts/backup-postgres.sh
+```
+
+Restore a backup explicitly:
+
+```bash
+bash ./scripts/restore-postgres.sh /opt/tennisscore/backups/tennisscore-postgres-YYYYMMDDTHHMMSSZ.dump.gz
+```
+
+The restore script asks for a `RESTORE` confirmation before running `pg_restore --clean --if-exists`.
+
+Example daily cron entry:
+
+```cron
+15 2 * * * cd /opt/tennisscore && BACKUP_DIR=/opt/tennisscore/backups bash ./scripts/backup-postgres.sh >> /opt/tennisscore/backups/backup.log 2>&1
+```
+
 ## Docker Images
 
 The production compose file expects these images by default:

--- a/README.md
+++ b/README.md
@@ -286,6 +286,12 @@ Example daily cron entry:
 15 2 * * * cd /opt/tennisscore && BACKUP_DIR=/opt/tennisscore/backups bash ./scripts/backup-postgres.sh >> /opt/tennisscore/backups/backup.log 2>&1
 ```
 
+Test the backup/restore scripts against an isolated temporary PostgreSQL container:
+
+```bash
+bash ./scripts/test-postgres-backup-restore.sh
+```
+
 ## Docker Images
 
 The production compose file expects these images by default:

--- a/backups/.gitignore
+++ b/backups/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/backups/.gitignore
+++ b/backups/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/scripts/backup-postgres.sh
+++ b/scripts/backup-postgres.sh
@@ -5,24 +5,30 @@ SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 REPO_DIR="$(cd -- "$SCRIPT_DIR/.." && pwd)"
 
 COMPOSE_FILE="${COMPOSE_FILE:-docker-compose.prod.yml}"
+COMPOSE_FILES="${COMPOSE_FILES:-$COMPOSE_FILE}"
 ENV_FILE="${ENV_FILE:-.env.prod}"
 BACKUP_DIR="${BACKUP_DIR:-./backups}"
 RETENTION_DAYS="${RETENTION_DAYS:-14}"
 
 cd "$REPO_DIR"
 
-if [[ ! -f "$COMPOSE_FILE" ]]; then
-  echo "Missing compose file: $COMPOSE_FILE" >&2
-  exit 1
-fi
-
 if [[ ! -f "$ENV_FILE" ]]; then
   echo "Missing environment file: $ENV_FILE" >&2
   exit 1
 fi
 
+COMPOSE_ARGS=()
+IFS=':' read -r -a compose_files <<< "$COMPOSE_FILES"
+for compose_file in "${compose_files[@]}"; do
+  if [[ ! -f "$compose_file" ]]; then
+    echo "Missing compose file: $compose_file" >&2
+    exit 1
+  fi
+  COMPOSE_ARGS+=("-f" "$compose_file")
+done
+
 compose() {
-  docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" "$@"
+  docker compose --env-file "$ENV_FILE" "${COMPOSE_ARGS[@]}" "$@"
 }
 
 mkdir -p "$BACKUP_DIR"

--- a/scripts/backup-postgres.sh
+++ b/scripts/backup-postgres.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd -- "$SCRIPT_DIR/.." && pwd)"
+
+COMPOSE_FILE="${COMPOSE_FILE:-docker-compose.prod.yml}"
+ENV_FILE="${ENV_FILE:-.env.prod}"
+BACKUP_DIR="${BACKUP_DIR:-./backups}"
+RETENTION_DAYS="${RETENTION_DAYS:-14}"
+
+cd "$REPO_DIR"
+
+if [[ ! -f "$COMPOSE_FILE" ]]; then
+  echo "Missing compose file: $COMPOSE_FILE" >&2
+  exit 1
+fi
+
+if [[ ! -f "$ENV_FILE" ]]; then
+  echo "Missing environment file: $ENV_FILE" >&2
+  exit 1
+fi
+
+compose() {
+  docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" "$@"
+}
+
+mkdir -p "$BACKUP_DIR"
+
+timestamp="$(date -u +"%Y%m%dT%H%M%SZ")"
+backup_file="$BACKUP_DIR/tennisscore-postgres-$timestamp.dump.gz"
+tmp_file="$backup_file.tmp"
+
+cleanup() {
+  rm -f "$tmp_file"
+}
+
+trap cleanup EXIT
+
+echo "Creating PostgreSQL backup: $backup_file"
+
+compose exec -T postgres sh -c 'pg_dump -U "$POSTGRES_USER" -d "$POSTGRES_DB" --format=custom --no-owner --no-acl' | gzip > "$tmp_file"
+
+mv "$tmp_file" "$backup_file"
+chmod 600 "$backup_file"
+
+if [[ "$RETENTION_DAYS" =~ ^[0-9]+$ ]] && [[ "$RETENTION_DAYS" -gt 0 ]]; then
+  find "$BACKUP_DIR" -type f -name "tennisscore-postgres-*.dump.gz" -mtime +"$RETENTION_DAYS" -delete
+fi
+
+echo "Backup completed: $backup_file"

--- a/scripts/restore-postgres.sh
+++ b/scripts/restore-postgres.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd -- "$SCRIPT_DIR/.." && pwd)"
+
+COMPOSE_FILE="${COMPOSE_FILE:-docker-compose.prod.yml}"
+ENV_FILE="${ENV_FILE:-.env.prod}"
+
+usage() {
+  cat <<USAGE
+Usage: ./scripts/restore-postgres.sh <backup-file.dump.gz>
+
+Restores a PostgreSQL custom-format backup into the running postgres service.
+This is destructive: existing database objects can be dropped and recreated.
+USAGE
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+backup_file="${1:-}"
+
+if [[ -z "$backup_file" ]]; then
+  usage >&2
+  exit 2
+fi
+
+if [[ ! -f "$backup_file" ]]; then
+  echo "Backup file not found: $backup_file" >&2
+  exit 1
+fi
+
+backup_file="$(cd -- "$(dirname -- "$backup_file")" && pwd)/$(basename -- "$backup_file")"
+
+cd "$REPO_DIR"
+
+if [[ ! -f "$COMPOSE_FILE" ]]; then
+  echo "Missing compose file: $COMPOSE_FILE" >&2
+  exit 1
+fi
+
+if [[ ! -f "$ENV_FILE" ]]; then
+  echo "Missing environment file: $ENV_FILE" >&2
+  exit 1
+fi
+
+compose() {
+  docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" "$@"
+}
+
+echo "About to restore backup into the PostgreSQL service."
+echo "Backup file: $backup_file"
+echo
+echo "This operation is destructive. Type RESTORE to continue:"
+read -r confirmation
+
+if [[ "$confirmation" != "RESTORE" ]]; then
+  echo "Restore cancelled."
+  exit 0
+fi
+
+echo "Restoring PostgreSQL backup..."
+
+gzip -dc "$backup_file" | compose exec -T postgres sh -c 'pg_restore -U "$POSTGRES_USER" -d "$POSTGRES_DB" --clean --if-exists --no-owner --no-acl --single-transaction --exit-on-error'
+
+echo "Restore completed."

--- a/scripts/restore-postgres.sh
+++ b/scripts/restore-postgres.sh
@@ -5,6 +5,7 @@ SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 REPO_DIR="$(cd -- "$SCRIPT_DIR/.." && pwd)"
 
 COMPOSE_FILE="${COMPOSE_FILE:-docker-compose.prod.yml}"
+COMPOSE_FILES="${COMPOSE_FILES:-$COMPOSE_FILE}"
 ENV_FILE="${ENV_FILE:-.env.prod}"
 
 usage() {
@@ -37,18 +38,23 @@ backup_file="$(cd -- "$(dirname -- "$backup_file")" && pwd)/$(basename -- "$back
 
 cd "$REPO_DIR"
 
-if [[ ! -f "$COMPOSE_FILE" ]]; then
-  echo "Missing compose file: $COMPOSE_FILE" >&2
-  exit 1
-fi
-
 if [[ ! -f "$ENV_FILE" ]]; then
   echo "Missing environment file: $ENV_FILE" >&2
   exit 1
 fi
 
+COMPOSE_ARGS=()
+IFS=':' read -r -a compose_files <<< "$COMPOSE_FILES"
+for compose_file in "${compose_files[@]}"; do
+  if [[ ! -f "$compose_file" ]]; then
+    echo "Missing compose file: $compose_file" >&2
+    exit 1
+  fi
+  COMPOSE_ARGS+=("-f" "$compose_file")
+done
+
 compose() {
-  docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" "$@"
+  docker compose --env-file "$ENV_FILE" "${COMPOSE_ARGS[@]}" "$@"
 }
 
 echo "About to restore backup into the PostgreSQL service."

--- a/scripts/test-postgres-backup-restore.sh
+++ b/scripts/test-postgres-backup-restore.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd -- "$SCRIPT_DIR/.." && pwd)"
+
+cd "$REPO_DIR"
+
+test_id="$(date -u +"%Y%m%d%H%M%S")-$$"
+work_dir="$(mktemp -d "${TMPDIR:-/tmp}/tennisscore-backup-test.XXXXXX")"
+env_file="$work_dir/.env.test"
+override_file="$work_dir/docker-compose.test.yml"
+backup_dir="$work_dir/backups"
+compose_project="tennisscore_backup_test_$test_id"
+
+cleanup() {
+  local exit_code=$?
+  COMPOSE_PROJECT_NAME="$compose_project" docker compose --env-file "$env_file" -f docker-compose.prod.yml -f "$override_file" down -v --remove-orphans >/dev/null 2>&1 || true
+  rm -rf "$work_dir"
+  exit "$exit_code"
+}
+
+trap cleanup EXIT
+
+cat > "$env_file" <<ENV
+API_IMAGE=1fini/tennisscoreapi:latest
+MIGRATIONS_IMAGE=1fini/tennisscoreapi-migrations:latest
+WEBAPP_IMAGE=1fini/tennisscore-webapp:latest
+ASPNETCORE_ENVIRONMENT=Production
+ENABLE_HTTPS_REDIRECTION=false
+WEBAPP_HTTP_PORT=18080
+DB_NAME=tennisscore_test
+DB_USER=tennisscore_test
+DB_PASSWORD=tennisscore_test_password
+ENV
+
+cat > "$override_file" <<YAML
+services:
+  postgres:
+    container_name: tennisscore-postgres-backup-test-$test_id
+    restart: "no"
+  migrations:
+    container_name: tennisscore-migrations-backup-test-$test_id
+  api:
+    container_name: tennisscore-api-backup-test-$test_id
+  webapp:
+    container_name: tennisscore-webapp-backup-test-$test_id
+    ports: []
+YAML
+
+compose() {
+  COMPOSE_PROJECT_NAME="$compose_project" docker compose --env-file "$env_file" -f docker-compose.prod.yml -f "$override_file" "$@"
+}
+
+echo "Starting isolated PostgreSQL test container"
+compose up -d postgres
+
+echo "Waiting for PostgreSQL readiness"
+for _ in {1..30}; do
+  if compose exec -T postgres sh -c 'pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB"' >/dev/null 2>&1; then
+    break
+  fi
+  sleep 1
+done
+
+compose exec -T postgres sh -c 'pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB"' >/dev/null
+
+echo "Creating probe data"
+compose exec -T postgres sh -c 'psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c "CREATE TABLE backup_probe (id integer PRIMARY KEY, label text NOT NULL);" -c "INSERT INTO backup_probe (id, label) VALUES (1, '\''before-restore'\'');"'
+
+echo "Running backup script"
+COMPOSE_PROJECT_NAME="$compose_project" \
+COMPOSE_FILES="docker-compose.prod.yml:$override_file" \
+ENV_FILE="$env_file" \
+BACKUP_DIR="$backup_dir" \
+RETENTION_DAYS=0 \
+bash ./scripts/backup-postgres.sh
+
+backup_file="$(find "$backup_dir" -type f -name "tennisscore-postgres-*.dump.gz" | head -n 1)"
+if [[ -z "$backup_file" ]]; then
+  echo "No backup file was created" >&2
+  exit 1
+fi
+
+echo "Mutating database after backup"
+compose exec -T postgres sh -c 'psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c "DROP TABLE backup_probe;"'
+
+echo "Running restore script"
+printf 'RESTORE\n' | COMPOSE_PROJECT_NAME="$compose_project" \
+COMPOSE_FILES="docker-compose.prod.yml:$override_file" \
+ENV_FILE="$env_file" \
+bash ./scripts/restore-postgres.sh "$backup_file"
+
+echo "Verifying restored data"
+restored_value="$(compose exec -T postgres sh -c 'psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -tAc "SELECT label FROM backup_probe WHERE id = 1;"')"
+
+if [[ "$restored_value" != "before-restore" ]]; then
+  echo "Unexpected restored value: $restored_value" >&2
+  exit 1
+fi
+
+echo "Backup and restore test completed successfully"


### PR DESCRIPTION
## Summary

- Add a PostgreSQL backup script using `pg_dump` from the running Docker Compose `postgres` service.
- Add a guarded restore script using `pg_restore` with an explicit `RESTORE` confirmation.
- Add a tracked `backups/.gitignore` placeholder so local backup files stay out of Git.
- Document backup, restore, retention, and cron usage in the README.

## Validation

- `bash -n scripts/backup-postgres.sh`
- `bash -n scripts/restore-postgres.sh`
- `docker compose --env-file .env.prod.example -f docker-compose.prod.yml config`

Note: Git push from the local workspace is still blocked by the unavailable `credential-osxkeychain` helper, so this branch was published through the GitHub connector.